### PR TITLE
Allow bucket region to be specified

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -6,6 +6,8 @@ module "s3_lb_log" {
   versioning_enabled = false
   force_destroy      = true
 
+  region = "us-west-1"
+
   lifecycle_rule_enabled                     = true
   lifecycle_rule_prefix                      = ""
   standard_ia_transition_days                = "60"

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,9 @@ resource "aws_s3_bucket" "default" {
   # https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
   bucket = "${var.name}"
 
+  # The AWS region this bucket should reside in. Otherwise, the region used by the callee.
+  region = "${local.bucket_region}"
+
   # S3 access control lists (ACLs) enable you to manage access to buckets and objects.
   # https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html
   acl = "private"
@@ -130,3 +133,11 @@ data "aws_iam_policy_document" "default" {
 
 # https://www.terraform.io/docs/providers/aws/d/elb_service_account.html
 data "aws_elb_service_account" "default" {}
+
+# https://www.terraform.io/docs/providers/aws/d/region.html
+# Get the region of the callee
+data "aws_region" "current" {}
+
+locals {
+  bucket_region = "${var.region == "" ? data.aws_region.current.name : var.region}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -67,3 +67,9 @@ variable "tags" {
   default     = {}
   description = "A mapping of tags to assign to the bucket."
 }
+
+variable "region" {
+  type        = "string"
+  description = "(Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee."
+  default     = ""
+}


### PR DESCRIPTION
This request allows the ability to specify the bucket region aside from just the callee region.  If no region is specified it falls back to the callee, to allow for backward compatibility.